### PR TITLE
Improve badge saving and push function

### DIFF
--- a/badge.svg
+++ b/badge.svg
@@ -12,7 +12,7 @@
   <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="start" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="12" id="svg_3" y="13.9" x="2.2" stroke-width="0" stroke="#4c4c4c" fill="#ffffff">coverage</text>
   <rect rx="2" id="svg_5" height="18" width="40.90531" y="1.01077" x="58.13716" stroke-width="1.5" stroke="#e05d44" fill="#e05d44"/>
   <rect id="svg_7" height="18" width="10" y="1.01077" x="58.00804" stroke-width="1.5" stroke="#e05d44" fill="#e05d44"/>
-  <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_10" y="14.35" x="99" stroke-width="0" stroke="#4c4c4c" fill="#6e747d">11 %</text>
-  <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_9" y="13.8" x="98.4" stroke-width="0" stroke="#4c4c4c" fill="#ffffff">11 %</text>
+  <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_10" y="14.35" x="99" stroke-width="0" stroke="#4c4c4c" fill="#6e747d">25 %</text>
+  <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_9" y="13.8" x="98.4" stroke-width="0" stroke="#4c4c4c" fill="#ffffff">25 %</text>
  </g>
 </svg>

--- a/clover.xml
+++ b/clover.xml
@@ -1,33 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1607775357">
-  <project timestamp="1607775357">
+<coverage generated="1607778409">
+  <project timestamp="1607778409">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
-        <metrics complexity="7" methods="5" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="16" coveredstatements="0" elements="21" coveredelements="0"/>
+        <metrics complexity="8" methods="5" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="20" coveredstatements="8" elements="25" coveredelements="10"/>
       </class>
-      <line num="17" type="method" name="__construct" visibility="public" complexity="1" crap="2" count="0"/>
-      <line num="19" type="stmt" count="0"/>
-      <line num="20" type="stmt" count="0"/>
+      <line num="17" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="2"/>
+      <line num="19" type="stmt" count="2"/>
+      <line num="20" type="stmt" count="2"/>
       <line num="22" type="method" name="generateBadge" visibility="public" complexity="1" crap="2" count="0"/>
       <line num="24" type="stmt" count="0"/>
-      <line num="25" type="stmt" count="0"/>
       <line num="26" type="stmt" count="0"/>
-      <line num="28" type="stmt" count="0"/>
-      <line num="30" type="method" name="formatCoverageNumber" visibility="private" complexity="1" crap="2" count="0"/>
+      <line num="27" type="stmt" count="0"/>
+      <line num="29" type="stmt" count="0"/>
+      <line num="30" type="stmt" count="0"/>
       <line num="32" type="stmt" count="0"/>
-      <line num="35" type="method" name="matchCoverageColor" visibility="private" complexity="3" crap="12" count="0"/>
+      <line num="33" type="stmt" count="0"/>
+      <line num="35" type="method" name="formatCoverageNumber" visibility="private" complexity="1" crap="2" count="0"/>
       <line num="37" type="stmt" count="0"/>
-      <line num="38" type="stmt" count="0"/>
-      <line num="39" type="stmt" count="0"/>
+      <line num="40" type="method" name="matchCoverageColor" visibility="private" complexity="3" crap="12" count="0"/>
       <line num="42" type="stmt" count="0"/>
-      <line num="44" type="method" name="saveBadge" visibility="public" complexity="1" crap="2" count="0"/>
-      <line num="46" type="stmt" count="0"/>
-      <line num="48" type="stmt" count="0"/>
-      <line num="49" type="stmt" count="0"/>
-      <line num="51" type="stmt" count="0"/>
-      <line num="52" type="stmt" count="0"/>
-      <line num="53" type="stmt" count="0"/>
-      <metrics loc="52" ncloc="52" classes="1" methods="5" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="16" coveredstatements="0" elements="21" coveredelements="0"/>
+      <line num="43" type="stmt" count="0"/>
+      <line num="44" type="stmt" count="0"/>
+      <line num="47" type="stmt" count="0"/>
+      <line num="49" type="method" name="saveBadge" visibility="public" complexity="2" crap="2" count="2"/>
+      <line num="51" type="stmt" count="2"/>
+      <line num="52" type="stmt" count="2"/>
+      <line num="54" type="stmt" count="2"/>
+      <line num="55" type="stmt" count="1"/>
+      <line num="58" type="stmt" count="2"/>
+      <line num="59" type="stmt" count="2"/>
+      <line num="60" type="stmt" count="1"/>
+      <metrics loc="59" ncloc="59" classes="1" methods="5" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="20" coveredstatements="8" elements="25" coveredelements="10"/>
     </file>
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/CoverageReportParser.php">
       <class name="PhpUnitCoverageBadge\CoverageReportParser" namespace="global">
@@ -87,6 +91,6 @@
       <line num="26" type="stmt" count="0"/>
       <metrics loc="27" ncloc="27" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="17" coveredstatements="0" elements="17" coveredelements="0"/>
     </file>
-    <metrics files="4" loc="157" ncloc="144" classes="3" methods="9" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="53" coveredstatements="6" elements="62" coveredelements="7"/>
+    <metrics files="4" loc="164" ncloc="151" classes="3" methods="9" coveredmethods="3" conditionals="0" coveredconditionals="0" statements="57" coveredstatements="14" elements="66" coveredelements="17"/>
   </project>
 </coverage>

--- a/src/BadgeGenerator.php
+++ b/src/BadgeGenerator.php
@@ -21,10 +21,15 @@ class BadgeGenerator
 
     public function generateBadge(float $codeCoverage)
     {
-        $this->saveBadge(
-            $this->formatCoverageNumber($codeCoverage),
-            $color = $this->matchCoverageColor($codeCoverage)
-        );
+        $template = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '../template.svg');
+
+        $formattedCoverage = $this->formatCoverageNumber($codeCoverage);
+        $color = $this->matchCoverageColor($codeCoverage);
+
+        $badge = str_replace('$cov$', $formattedCoverage, $template);
+        $badge = str_replace('$color$', $color, $badge);
+
+        $this->saveBadge($badge);
     }
 
     private function formatCoverageNumber(float $coverage): string
@@ -41,13 +46,15 @@ class BadgeGenerator
         }
     }
 
-    public function saveBadge(string $formattedCoverage, string $color)
+    public function saveBadge(string $badge)
     {
-        $template = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '../template.svg');
+        $badgeTargetPath = __DIR__ . DIRECTORY_SEPARATOR . '../' . $this->badgePath;
+        $targetDirectory = dirname($badgeTargetPath);
 
-        $badge = str_replace('$cov$', $formattedCoverage, $template);
-        $badge = str_replace('$color$', $color, $badge);
+        if (!is_dir($targetDirectory)) {
+            mkdir($targetDirectory, 0777, true);
+        }
 
-        file_put_contents(__DIR__ . DIRECTORY_SEPARATOR . '../' . $this->badgePath, $badge);
+        file_put_contents($badgeTargetPath, $badge);
     }
 }

--- a/src/commit_push_badge.sh
+++ b/src/commit_push_badge.sh
@@ -7,4 +7,4 @@ git config user.name "${INPUT_COMMIT_NAME}"
 
 git commit -m "${INPUT_COMMIT_MESSAGE}"
 
-git push https://"${GITHUB_ACTOR}":"${INPUT_REPO_TOKEN}"@github.com/"${GITHUB_REPOSITORY}".git HEAD:"${GITHUB_REF##*/}";
+git push https://"${GITHUB_ACTOR}":"${INPUT_REPO_TOKEN}"@github.com/"${GITHUB_REPOSITORY}".git HEAD:"${GITHUB_REF#refs/heads/}";

--- a/tests/BadgeGeneratorTest.php
+++ b/tests/BadgeGeneratorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+
+use PHPUnit\Framework\TestCase;
+use PhpUnitCoverageBadge\BadgeGenerator;
+
+class BadgeGeneratorTest extends TestCase
+{
+    const VALID_BADGE = <<<EOT
+<svg width="100" height="20" xmlns="http://www.w3.org/2000/svg">
+<!-- Created with Method Draw - http://github.com/duopixel/Method-Draw/ -->
+
+ <g>
+  <title>background</title>
+  <rect fill="none" id="canvas_background" height="22" width="102" y="-1" x="-1"/>
+ </g>
+ <g>
+  <title>Layer 1</title>
+  <rect rx="2" id="svg_1" height="18" width="98" y="1" x="1" stroke-width="1.5" stroke="#4c4c4c" fill="#4c4c4c"/>
+  <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="start" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="12" id="svg_8" y="14.45" x="2.8" stroke-width="0" stroke="#4c4c4c" fill="#6e747d">coverage</text>
+  <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="start" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="12" id="svg_3" y="13.9" x="2.2" stroke-width="0" stroke="#4c4c4c" fill="#ffffff">coverage</text>
+  <rect rx="2" id="svg_5" height="18" width="40.90531" y="1.01077" x="58.13716" stroke-width="1.5" stroke="#e05d44" fill="#e05d44"/>
+  <rect id="svg_7" height="18" width="10" y="1.01077" x="58.00804" stroke-width="1.5" stroke="#e05d44" fill="#e05d44"/>
+  <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_10" y="14.35" x="99" stroke-width="0" stroke="#4c4c4c" fill="#6e747d">11 %</text>
+  <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_9" y="13.8" x="98.4" stroke-width="0" stroke="#4c4c4c" fill="#ffffff">11 %</text>
+ </g>
+</svg>
+EOT;
+
+    public function testDirectoryDoesNotExistPreviously()
+    {
+        $badgeGenerator = new BadgeGenerator('tests/this/is/no/directory/test_badge.svg');
+
+        $badgeGenerator->saveBadge(self::VALID_BADGE);
+
+        $this->assertFileExists(__DIR__ . '/this/is/no/directory/test_badge.svg');
+
+        if (file_exists(__DIR__ . '/this/is/no/directory/test_badge.svg')) {
+            unlink(__DIR__ . '/this/is/no/directory/test_badge.svg');
+            rmdir(__DIR__ . '/this/is/no/directory');
+            rmdir(__DIR__ . '/this/is/no');
+            rmdir(__DIR__ . '/this/is');
+            rmdir(__DIR__ . '/this');
+        }
+    }
+
+    public function testOverwritingBadge()
+    {
+        $badgeGenerator = new BadgeGenerator('tests/resources/test_badge.svg');
+
+        $badgeGenerator->saveBadge(self::VALID_BADGE);
+
+        $badgePath = __DIR__ . '/resources/test_badge.svg';
+        if (file_exists($badgePath)) {
+            $updatedBadgeContent = file_get_contents($badgePath);
+
+            $this->assertEquals(self::VALID_BADGE, $updatedBadgeContent);
+
+            unlink($badgePath);
+            copy(dirname($badgePath) . '/test_badge_backup.svg', $badgePath);
+        }
+    }
+}

--- a/tests/resources/test_badge.svg
+++ b/tests/resources/test_badge.svg
@@ -1,0 +1,18 @@
+<svg width="100" height="20" xmlns="http://www.w3.org/2000/svg">
+    <!-- Created with Method Draw - http://github.com/duopixel/Method-Draw/ -->
+
+    <g>
+        <title>background</title>
+        <rect fill="none" id="canvas_background" height="22" width="102" y="-1" x="-1"/>
+    </g>
+    <g>
+        <title>Layer 1</title>
+        <rect rx="2" id="svg_1" height="18" width="98" y="1" x="1" stroke-width="1.5" stroke="#4c4c4c" fill="#4c4c4c"/>
+        <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="start" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="12" id="svg_8" y="14.45" x="2.8" stroke-width="0" stroke="#4c4c4c" fill="#6e747d">coverage</text>
+        <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="start" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="12" id="svg_3" y="13.9" x="2.2" stroke-width="0" stroke="#4c4c4c" fill="#ffffff">coverage</text>
+        <rect rx="2" id="svg_5" height="18" width="40.90531" y="1.01077" x="58.13716" stroke-width="1.5" stroke="#e05d44" fill="#e05d44"/>
+        <rect id="svg_7" height="18" width="10" y="1.01077" x="58.00804" stroke-width="1.5" stroke="#e05d44" fill="#e05d44"/>
+        <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_10" y="14.35" x="99" stroke-width="0" stroke="#4c4c4c" fill="#6e747d">0 %</text>
+        <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_9" y="13.8" x="98.4" stroke-width="0" stroke="#4c4c4c" fill="#ffffff">0 %</text>
+    </g>
+</svg>

--- a/tests/resources/test_badge_backup.svg
+++ b/tests/resources/test_badge_backup.svg
@@ -1,0 +1,18 @@
+<svg width="100" height="20" xmlns="http://www.w3.org/2000/svg">
+    <!-- Created with Method Draw - http://github.com/duopixel/Method-Draw/ -->
+
+    <g>
+        <title>background</title>
+        <rect fill="none" id="canvas_background" height="22" width="102" y="-1" x="-1"/>
+    </g>
+    <g>
+        <title>Layer 1</title>
+        <rect rx="2" id="svg_1" height="18" width="98" y="1" x="1" stroke-width="1.5" stroke="#4c4c4c" fill="#4c4c4c"/>
+        <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="start" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="12" id="svg_8" y="14.45" x="2.8" stroke-width="0" stroke="#4c4c4c" fill="#6e747d">coverage</text>
+        <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="start" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="12" id="svg_3" y="13.9" x="2.2" stroke-width="0" stroke="#4c4c4c" fill="#ffffff">coverage</text>
+        <rect rx="2" id="svg_5" height="18" width="40.90531" y="1.01077" x="58.13716" stroke-width="1.5" stroke="#e05d44" fill="#e05d44"/>
+        <rect id="svg_7" height="18" width="10" y="1.01077" x="58.00804" stroke-width="1.5" stroke="#e05d44" fill="#e05d44"/>
+        <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_10" y="14.35" x="99" stroke-width="0" stroke="#4c4c4c" fill="#6e747d">0 %</text>
+        <text transform="matrix(0.95, 0, 0, 1.01133, 0.0809801, -0.0237383)" font-weight="normal" xml:space="preserve" text-anchor="end" font-family="'Trebuchet MS', Gadget, sans-serif" font-size="10" id="svg_9" y="13.8" x="98.4" stroke-width="0" stroke="#4c4c4c" fill="#ffffff">0 %</text>
+    </g>
+</svg>


### PR DESCRIPTION
- The badge path is now checked for existence. If it does not exist it will be created. Also added tests for creating a path and overwriting an existing badge.
- Badge pushing does now work for non-single word branch names. E.g. feature/posts did not work previously and changes would have been pushed into "posts". 