### PR TITLE
Increase speed of action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,18 +47,17 @@ jobs:
         id: cache-docker-image
         uses: actions/cache@v2
         with:
-          path: tmp/coverageBadge.tar
-          key: ${{ runner.os }}-coverage-image
+          path: ~/docker-temp/coverageBadge.tar
+          key: ${{ runner.os }}-image
 
       - name: Load docker image
         if: steps.cache-docker-image.outputs.cache-hit == 'true'
-        run: /usr/bin/docker load < tmp/coverageBadge.tar
+        run: /usr/bin/docker load < ~/docker-temp/coverageBadge.tar
 
       - name: Generate test coverage badge
         uses: ./
         with:
           coverage_badge_path: 'badge.svg'
-          push_badge: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save docker image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,12 +43,10 @@ jobs:
       - name: Run Unit Tests
         run: XDEBUG_MODE_COVERAGE=coverage vendor/bin/phpunit
 
-      # In this step, this action saves a list of existing images,
-      # the cache is created without them in the post run.
-      # It also restores the cache if it exists.
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
+        with:
+          concurrency: 20
 
       - name: Generate test coverage badge
         uses: ./

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: var/lib/docker
-          key: ${{ runner.os }}-docker-image
+          key: ${{ runner.os }}-docker-images
 
       - name: Docker images
         id: docker-images-2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,16 @@ jobs:
       - name: Run Unit Tests
         run: XDEBUG_MODE_COVERAGE=coverage vendor/bin/phpunit
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - name: Cache docker container
+        id: cache-docker-image
+        uses: actions/cache@v2
         with:
-          concurrency: 20
+          path: tmp/coverageBadge.tar
+          key: ${{ runner.os }}-coverage-image
+
+      - name: Load docker image
+        if: steps.cache-docker-image.outputs.cache-hit != 'true'
+        run: /usr/bin/docker load < tmp/coverageBadge.tar
 
       - name: Generate test coverage badge
         uses: ./
@@ -54,3 +60,6 @@ jobs:
           coverage_badge_path: 'badge.svg'
           push_badge: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save docker image
+        run: /usr/bin/docker save ghcr.io/timkrase/phpunit-coverage-badge > tmp/coverageBadge.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,5 +65,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker images
-        id: docker-images
+        id: docker-images-2
         run: /usr/bin/docker image ls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,17 +52,17 @@ jobs:
       - name: Run Unit Tests
         run: XDEBUG_MODE_COVERAGE=coverage vendor/bin/phpunit
 
-      - uses: actions/cache@v2
-        with:
-          path: var/lib/docker
-          key: ${{ runner.os }}-docker-image
-
       - name: Generate test coverage badge
         uses: ./
         with:
           coverage_badge_path: 'badge.svg'
           push_badge: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/cache@v2
+        with:
+          path: var/lib/docker
+          key: ${{ runner.os }}-docker-image
 
       - name: Docker images
         id: docker-images-2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           key: ${{ runner.os }}-coverage-image
 
       - name: Load docker image
-        if: steps.cache-docker-image.outputs.cache-hit = 'true'
+        if: steps.cache-docker-image.outputs.cache-hit == 'true'
         run: /usr/bin/docker load < tmp/coverageBadge.tar
 
       - name: Generate test coverage badge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,4 +62,4 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save docker image
-        run: mkdir -p ~/docker-temp/ && /usr/bin/docker save ghcr.io/timkrase/phpunit-coverage-badge > tmp/coverageBadge.tar
+        run: mkdir -p ~/docker-temp/ && /usr/bin/docker save ghcr.io/timkrase/phpunit-coverage-badge > ~/docker-temp/coverageBadge.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,7 @@ jobs:
           coverage_badge_path: 'badge.svg'
           push_badge: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker images
+        id: docker-images
+        run: /usr/bin/docker image ls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,22 +43,9 @@ jobs:
       - name: Run Unit Tests
         run: XDEBUG_MODE_COVERAGE=coverage vendor/bin/phpunit
 
-      - name: Cache docker container
-        id: cache-docker-image
-        uses: actions/cache@v2
-        with:
-          path: ~/docker-temp/coverageBadge.tar
-          key: ${{ runner.os }}-image
-
-      - name: Load docker image
-        if: steps.cache-docker-image.outputs.cache-hit == 'true'
-        run: /usr/bin/docker load < ~/docker-temp/coverageBadge.tar
-
       - name: Generate test coverage badge
         uses: ./
         with:
           coverage_badge_path: 'badge.svg'
+          push_badge: 'true'
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save docker image
-        run: mkdir -p ~/docker-temp/ && /usr/bin/docker save ghcr.io/timkrase/phpunit-coverage-badge > ~/docker-temp/coverageBadge.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Run Unit Tests
         run: XDEBUG_MODE_COVERAGE=coverage vendor/bin/phpunit
 
+      - uses: actions/cache@v2
+        with:
+          path: var/lib/docker
+
       - name: Generate test coverage badge
         uses: ./
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Docker info
+        id: docker-info
+        run: /usr/bin/docker info
+
       - name: Setup PHP
         uses: shivammathur/setup-php@2.9.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-
-      - name: Docker images
-        id: docker-images
-        run: /usr/bin/docker image ls
-
-      - name: Docker info
-        id: docker-info
-        run: /usr/bin/docker info
-
       - name: Setup PHP
         uses: shivammathur/setup-php@2.9.0
         with:
@@ -52,18 +43,16 @@ jobs:
       - name: Run Unit Tests
         run: XDEBUG_MODE_COVERAGE=coverage vendor/bin/phpunit
 
+      # In this step, this action saves a list of existing images,
+      # the cache is created without them in the post run.
+      # It also restores the cache if it exists.
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
+
       - name: Generate test coverage badge
         uses: ./
         with:
           coverage_badge_path: 'badge.svg'
           push_badge: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/cache@v2
-        with:
-          path: /var/lib/docker
-          key: ${{ runner.os }}-image
-
-      - name: Docker images
-        id: docker-images-2
-        run: /usr/bin/docker image ls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           key: ${{ runner.os }}-coverage-image
 
       - name: Load docker image
-        if: steps.cache-docker-image.outputs.cache-hit != 'true'
+        if: steps.cache-docker-image.outputs.cache-hit = 'true'
         run: /usr/bin/docker load < tmp/coverageBadge.tar
 
       - name: Generate test coverage badge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: var/lib/docker
+          key: ${{ runner.os }}-docker-image
 
       - name: Generate test coverage badge
         uses: ./

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,5 +47,5 @@ jobs:
         uses: ./
         with:
           coverage_badge_path: 'badge.svg'
-          push_badge: 'true'
+          push_badge: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+
+      - name: Docker images
+        id: docker-images
+        run: /usr/bin/docker image ls
+
       - name: Docker info
         id: docker-info
         run: /usr/bin/docker info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,4 +62,4 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save docker image
-        run: /usr/bin/docker save ghcr.io/timkrase/phpunit-coverage-badge > tmp/coverageBadge.tar
+        run: mkdir -p ~/docker-temp/ && /usr/bin/docker save ghcr.io/timkrase/phpunit-coverage-badge > tmp/coverageBadge.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,8 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: var/lib/docker
-          key: ${{ runner.os }}-docker-images
+          path: /var/lib/docker
+          key: ${{ runner.os }}-image
 
       - name: Docker images
         id: docker-images-2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM php:7.4-cli
+FROM ghcr.io/timkrase/phpunit-coverage-badge:v1.0.0
 COPY entrypoint.sh /entrypoint.sh
-RUN apt-get update
-RUN apt-get install -y git
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM ghcr.io/timkrase/phpunit-coverage-badge:v1.0.0
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:7.4-cli
+COPY entrypoint.sh /entrypoint.sh
+RUN apt-get update
+RUN apt-get install -y git
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ inputs:
     default: 'Github Actions Bot'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'ghcr.io/timkrase/phpunit-coverage-badge:v1.0.0'
   args:
     - ${{ inputs.clover-report }}
     - ${{ inputs.coverage-badge-path }}

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ inputs:
     default: 'Github Actions Bot'
 runs:
   using: 'docker'
-  image: 'ghcr.io/timkrase/phpunit-coverage-badge:v1.0.0'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.clover-report }}
     - ${{ inputs.coverage-badge-path }}

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609098515">
-  <project timestamp="1609098515">
+<coverage generated="1609098928">
+  <project timestamp="1609098928">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609095511">
-  <project timestamp="1609095511">
+<coverage generated="1609095652">
+  <project timestamp="1609095652">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609095372">
-  <project timestamp="1609095372">
+<coverage generated="1609095511">
+  <project timestamp="1609095511">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609094587">
-  <project timestamp="1609094587">
+<coverage generated="1609094792">
+  <project timestamp="1609094792">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609095731">
-  <project timestamp="1609095731">
+<coverage generated="1609096390">
+  <project timestamp="1609096390">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609098928">
-  <project timestamp="1609098928">
+<coverage generated="1609099068">
+  <project timestamp="1609099068">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609094238">
-  <project timestamp="1609094238">
+<coverage generated="1609094587">
+  <project timestamp="1609094587">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609094792">
-  <project timestamp="1609094792">
+<coverage generated="1609095372">
+  <project timestamp="1609095372">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609097026">
-  <project timestamp="1609097026">
+<coverage generated="1609098108">
+  <project timestamp="1609098108">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609095652">
-  <project timestamp="1609095652">
+<coverage generated="1609095731">
+  <project timestamp="1609095731">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609096390">
-  <project timestamp="1609096390">
+<coverage generated="1609097026">
+  <project timestamp="1609097026">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609098306">
-  <project timestamp="1609098306">
+<coverage generated="1609098515">
+  <project timestamp="1609098515">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>

--- a/clover.xml
+++ b/clover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1609098108">
-  <project timestamp="1609098108">
+<coverage generated="1609098306">
+  <project timestamp="1609098306">
     <file name="/home/runner/work/phpunit-coverage-badge/phpunit-coverage-badge/src/BadgeGenerator.php">
       <class name="PhpUnitCoverageBadge\BadgeGenerator" namespace="global">
         <metrics complexity="7" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="19" coveredstatements="19" elements="23" coveredelements="23"/>


### PR DESCRIPTION
Different ways to cache and build the docker image have been tested to find ways to increase the speed of the action. The only noticeable speed improvement came from building the image and pushing it to the Github container registry outside of the action. The action then pulls it from there instead of building it itself. This cuts the time from ~31 to ~21 seconds for this project. 